### PR TITLE
Rewrite `tables.lazyModule` to permit deferred initialization

### DIFF
--- a/tables.lua
+++ b/tables.lua
@@ -112,54 +112,30 @@ end
 ---@param t table<K, any>
 ---@return table<K, any>
 function lazyModule(t)
-  ---@type table<any, any>
-  local init = {}
-  ---@type table<any, fun(): any>
-  local accessors = {}
-
-  for k, v in pairs(t) do
-    if isLazyKey(k) then
-      if type(v) == "function" then
-        accessors[k] = v
-      else
-        init[k] = v
-      end
-    end
-  end
-
-  local function lazyNext(_, k)
-    local v
-    if k == nil or init[k] ~= nil then
-      k, v = next(init, k)
-      if k == nil then
-        k, v = next(accessors, k)
-        if v then v = v() end
-      end
-    else
-      k, v = next(accessors, k)
-      if v then v = v() end
-    end
-    if k == nil then
-      return nil
-    end
-    return k, v
+  local function lazyNext(self, prev)
+    local k = next(t, prev)
+    return k, self[k]
   end
 
   return setmetatable({}, {
+    __name = "lazyModule";
     __metatable = false;
-    __index = lazy(function(_, k)
-      local f = accessors[k]
-      if f then
-        return f()
+    __index = lazy(function(self, k)
+      local v = t[k]
+      if type(v) == "function" then
+        return v(self, k)
       else
-        return nil
+        return v
       end
-    end, init);
+    end);
     __setindex = function()
       error("cannot modify lazy module")
     end;
-    __pairs = function(obj)
-      return lazyNext, obj, nil
+    __len = function()
+      return #t
+    end;
+    __pairs = function(self)
+      return lazyNext, self, nil
     end;
   })
 end


### PR DESCRIPTION
I want to be able to write:

```lua
local getters <const> = {}
local module <const> = setmetatable({}, { __index = tables.lazyModule(getters) })

function getters:foo()
  return "bar"
end

return module
```

Since freezing isn't mandatory until the `return`, then I should be able to continue mutating the `lazyModule` argument until the module is imported.

<!-- jj-domino -->
<!-- Do not remove this comment! Everything in this section will be rewritten by jj-domino. -->

## Related Pull Requests

This pull request is part of a stack managed by [jj-domino](https://github.com/zombiezen/jj-domino):

 1. *→ this pull request ←*
 2. #45
